### PR TITLE
Add Issue and PR templates

### DIFF
--- a/ISSUE_TEMPLATE/bug_report.md
+++ b/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,20 @@
+---
+name: Bug Report
+about: Report bugs and glitches / 発生した不具合や想定外の挙動について報告する
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## What / どのような問題か
+
+### Expected Behavior / 期待される振る舞い
+
+### Actual Behavior / 実際の振る舞い
+
+### Steps to Reproduce, Screenshots / 再現方法、スクリーンショット
+
+## Why / 何故そうなるべきか
+
+## Ref

--- a/ISSUE_TEMPLATE/general_issue.md
+++ b/ISSUE_TEMPLATE/general_issue.md
@@ -1,0 +1,20 @@
+---
+name: Issue
+about: Create issues for feature requests, logging, etc. / 改善点の提案や調査の記録などの為に Issue を作成する
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## What
+
+## Why
+
+## How
+
+## Goal
+
+## Non-Goal
+
+## Ref

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,7 @@
+## What
+
+## Why
+
+## How
+
+## Ref


### PR DESCRIPTION
## What
Issue テンプレートと PR テンプレートを用意する

## Why
- Speee Org 全体で適用されるデフォルトテンプレートがあると、個別のリポジトリにいちいちテンプレートを設定する必要が無くなって便利なので
- Issue や PR を作成する人間が必ずしも日本語話者であるという保証はないので、英語も併記することにした
- Speee Org 全体にデフォルトで適用される都合上、たとえば障害報告のような、特定の領域のみで求められる Issue テンプレートは作らずに、可能な限り汎用的なテンプレートにするようにした
  - 一方で汎用的なテンプレートであればあるほど、記述も汎用的になっていく傾向がある。これに関しては完全にトレードオフとなので、バグレポートだけ詳細なテンプレートを用意することにした